### PR TITLE
ci: make release run on main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,16 +25,16 @@ workflows:
   build-test:
     jobs:
       - test
-      - hold:
+      - hold_release:
           type: approval
           requires:
             - test
           filters:
             branches:
-              only: master
+              only: main
       - release:
           requires:
-            - hold
+            - hold_release
           filters:
             branches:
-              only: master
+              only: main


### PR DESCRIPTION
Make the `release` CI job run on `main` instead of `master` (which doesn't exist).