### PR TITLE
ci: fix release script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -4,7 +4,7 @@ if [ ! "${VERSION}" ] || [ -z "${VERSION}" ];then
     echo "Instabug: err: Version Number not found."
     exit 1
 else 
-    mkdir -p .pub-cache
+    mkdir -p $HOME/.config/dart
     cat <<EOF > $HOME/.config/dart/pub-credentials.json
     ${PUB_CREDENTIALS}
 


### PR DESCRIPTION
The `release.sh` script tries to create a `$HOME/.config/dart/pub-credentials.json` file while the directory containing it `$HOME/.config/dart` doesn't exist, so we need to create it if it doesn't exist before creating the file.